### PR TITLE
[RFR-450] Add group paramter to registration

### DIFF
--- a/src/main/kotlin/de/cyface/uploader/Authenticator.kt
+++ b/src/main/kotlin/de/cyface/uploader/Authenticator.kt
@@ -53,11 +53,12 @@ interface Authenticator {
      * @param password The password part of the credentials
      * @param captcha The captcha token
      * @param activation The template to use for the activation email.
+     * @param group The database identifier of the group the user selected during registration
      * @throws RegistrationFailed when an expected error occurred, so that the UI can handle this.
      * @return [Result.UPLOAD_SUCCESSFUL] if successful.
      */
     @Throws(RegistrationFailed::class)
-    fun register(email: String, password: String, captcha: String, activation: Activation): Result
+    fun register(email: String, password: String, captcha: String, activation: Activation, group: String): Result
 
     /**
      * @return the endpoint which will be used for authentication.

--- a/src/main/kotlin/de/cyface/uploader/DefaultAuthenticator.kt
+++ b/src/main/kotlin/de/cyface/uploader/DefaultAuthenticator.kt
@@ -47,7 +47,7 @@ import java.net.URL
  * Usually the token should be generated just before each [DefaultUploader.upload] call.
  *
  * @author Armin Schnabel
- * @version 1.0.0
+ * @version 1.0.1
  * @since 1.0.0
  * @property apiEndpoint An API endpoint running a Cyface data collector service, like `https://some.url/api/v3`
  */
@@ -117,13 +117,19 @@ class DefaultAuthenticator(private val apiEndpoint: String) : Authenticator {
     }
 
     @Suppress("CyclomaticComplexMethod")
-    override fun register(email: String, password: String, captcha: String, activation: Activation): Result {
+    override fun register(
+        email: String,
+        password: String,
+        captcha: String,
+        activation: Activation,
+        group: String
+    ): Result {
         var connection: HttpURLConnection? = null
         try {
             connection = http.open(registrationEndpoint(), false)
 
             // Try to send the request and handle expected errors
-            val response = http.register(connection, email, password, captcha, activation)
+            val response = http.register(connection, email, password, captcha, activation, group)
             LOGGER.debug("Response $response")
             return response
         }

--- a/src/main/kotlin/de/cyface/uploader/Http.kt
+++ b/src/main/kotlin/de/cyface/uploader/Http.kt
@@ -102,6 +102,7 @@ interface Http {
      * @param password The password part of the credentials
      * @param captcha The captcha token
      * @param activation The template to use for the activation email.
+     * @param group The database identifier of the group the user selected during registration
      * @throws SynchronisationException If an IOException occurred while reading the response code.
      * @throws BadRequestException When server returns `HttpURLConnection#HTTP_BAD_REQUEST`
      * @throws UnauthorizedException When the server returns `HttpURLConnection#HTTP_UNAUTHORIZED`
@@ -137,6 +138,7 @@ interface Http {
         email: String,
         password: String,
         captcha: String,
-        activation: Activation
+        activation: Activation,
+        group: String
     ): Result
 }

--- a/src/main/kotlin/de/cyface/uploader/HttpConnection.kt
+++ b/src/main/kotlin/de/cyface/uploader/HttpConnection.kt
@@ -132,12 +132,13 @@ class HttpConnection : Http {
         email: String,
         password: String,
         captcha: String,
-        activation: Activation
+        activation: Activation,
+        group: String
     ): Result {
         // For performance reasons (documentation) set either fixedLength (known length) or chunked streaming mode
         // we currently don't use fixedLengthStreamingMode as we only use this request for small login requests
         connection.setChunkedStreamingMode(0)
-        val payload = registrationPayload(email, password, captcha, activation)
+        val payload = registrationPayload(email, password, captcha, activation, group)
         val outputStream = initOutputStream(connection)
         try {
             outputStream.write(payload.toByteArray(DEFAULT_CHARSET))
@@ -172,9 +173,15 @@ class HttpConnection : Http {
         return "{\"username\":\"$username\",\"password\":\"$password\"}"
     }
 
-    private fun registrationPayload(email: String, password: String, captcha: String, template: Activation): String {
+    private fun registrationPayload(
+        email: String,
+        password: String,
+        captcha: String,
+        template: Activation,
+        group: String
+    ): String {
         return "{\"email\":\"$email\",\"password\":\"$password\",\"captcha\":\"$captcha\",\"template\":\"" +
-            "${template.name}\"}"
+            "${template.name}\",\"group\":\"$group\"}"
     }
 
     private fun gzip(input: ByteArray): ByteArray {


### PR DESCRIPTION
As the R4R user can now select a group during registration, `Authenticator.registration()` needs to support this parameter.